### PR TITLE
feat(semgrep): add blocking step to workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -49,7 +49,8 @@ jobs:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
       - name: Manage Semgrep Issue
-        uses: actions/github-script@v6
+        id: semgrep-results
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -277,3 +278,13 @@ jobs:
                 }
               }
             }
+            
+            core.setOutput('findings-count', total);
+            return total;
+      - name: Block CI on Security Issues
+        if: steps.semgrep-results.outputs.findings-count > 0
+        run: |
+          echo "❌ BLOCKING: Semgrep found ${{ steps.semgrep-results.outputs.findings-count }} security issue(s)"
+          echo "Please resolve all security findings before merging."
+          echo "Check the GitHub issue created for detailed information."
+          exit 1


### PR DESCRIPTION
## Motivation & Context
<!--- [if not specified in story] Why is this change required? What problem does it solve? -->
The previous Semgrep workflow allows PRs to be merged in even if issues are identified,

## Description
<!--- Provide a general summary and describe the changes in detail -->
Added the status check to fail when any issues are found.

## How has this been tested?
<!-- Provide proof of changes e.g. 

TF plan 
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  - destroy

Terraform will perform the following actions:

  # aws_route53_record.fover_dns_record[0] will be destroyed
  - resource "aws_route53_record" "fover_dns_record" {
      - fqdn    = "fover.stg.locus.gov.sg" -> null
    }
Plan: 2 to add, 0 to change, 4 to destroy.
```
-->
The workflow now fails when any issues are raised.
<img width="716" height="418" alt="{461F88F2-1409-4FC9-AC89-F279BF98FE84}" src="https://github.com/user-attachments/assets/36cace51-7ecc-4f64-93cc-0867ece9f7fe" />
